### PR TITLE
Autofix: Remove obsolete/unused scripts from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "build:clean": "rimraf dist",
     "build:lib": "rollup -c --bundleConfigAsCjs",
     "build:watch": "npm run build:clean && npm run build:lib -- --watch",
-    "ci:install": "npm ci && npm run website:install",
     "lint": "eslint --config ./.eslintrc.js --max-warnings 0 'src/**/*.{js,ts}' --fix",
     "lint:check": "eslint --config ./.eslintrc.js --max-warnings 0 'src/**/*.{js,ts}'",
     "pre-commit": "lint-staged",


### PR DESCRIPTION
I have removed the obsolete `ci:install` script from the package.json file. This script was referencing a non-existing `website:install` script, which is not present in the current project structure. Users should use the built-in `npm ci` command instead to install dependencies. This change simplifies the scripts section and removes potential confusion for developers. 
> [!CAUTION]  
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission