### PR TITLE
release(1.2.2): Improve addCatalog to always return catalog Id

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@capitalone/stratum-observability",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@capitalone/stratum-observability",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@rollup/plugin-replace": "^5.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capitalone/stratum-observability",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Library for defining and publishing observability events through plugin-based architecture",
   "license": "Apache-2.0",
   "repository": {

--- a/src/service.ts
+++ b/src/service.ts
@@ -107,16 +107,16 @@ export class StratumService {
    * Note: catalog item ids do not need to be unique across catalogs.
    *
    * @param {UserDefinedCatalogOptions} options - Catalog items and optional catalog version
-   * @return {string | undefined} Catalog id of newly registered catalog. Undefined if
-   *   catalog has already been registered.
+   * @return {string} Catalog id of newly registered catalog
    */
   addCatalog(options: UserDefinedCatalogOptions): string {
     const id = generateCatalogId(options, this.injector.productName, this.injector.productVersion);
     if (this.catalogs[id]) {
       this.injector.logger.debug(`Unable to register duplicate catalog "${id}"`);
-      return '';
+    } else {
+      this.catalogs[id] = new RegisteredStratumCatalog(id, options, this.injector);
     }
-    this.catalogs[id] = new RegisteredStratumCatalog(id, options, this.injector);
+
     return id;
   }
 

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -166,14 +166,14 @@ describe('stratum service base functionality', () => {
     expect(stratum.publishers[1]).toBeInstanceOf(BrowserConsolePublisher);
   });
 
-  it('should prevent multiple catalogs with the same id to be instantiated', () => {
+  it('should return catalog id even for duplicate catalogs', () => {
     // Add a standard catalog
     stratum.addCatalog({ items: SAMPLE_A_CATALOG, ...CATALOG_METADATA });
     expect(Object.keys(stratum.catalogs)).toHaveLength(2);
 
     // Attempt to add another catalog with the same metadata
     const id = stratum.addCatalog({ items: {}, ...CATALOG_METADATA });
-    expect(id).toBe('');
+    expect(id).toBe(METADATA_CATALOG_ID);
     expect(Object.keys(stratum.catalogs)).toHaveLength(2);
 
     // Update the metadata


### PR DESCRIPTION
- Modified addCatalog method to always return the catalog ID instead of empty string for duplicates
- Updated test to reflect new behavior: 'should return catalog id even for duplicate catalogs'
- This provides more consistent and predictable API behavior
- All tests pass with the new implementation

📣 **For new features and bugfixes, please create an issue first**  

#### ✔️ Checklist

Please review our [Contributor Docs](https://github.com/capitalone/Stratum-Observability/blob/main/CONTRIBUTING.md) for more details

* [x] Fixes #36
* [x] I have run `npm version [patch, minor, major]` (considering (semantic versioning)[https://semver.org/#summary)) for a new release if needed
* [x] If the package version changed, this PR's title is prefixed with `release([VERSION]): `
* [x] I have added [typedoc-style comments](https://typedoc.org/example/) to my changes to improve the developer experience

----

**⏩ Next steps:**
- Please ensure that all the automated pipeline steps pass
- Once your PR is opened, CODEOWNERS will be requested as reviewers. At least one review from a CODEOWNER is required to merge your PR
- Once approved, a CODEOWNER will merge your changes and perform any other necessary release tasks
