### PR TITLE
release(1.2.3): Allow Event Key to be Used as ID When id is Omitted

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ A typical Stratum implementation consists of:
         [EventKey.LOADED]: {
           eventType: 'base', // The base event type for Stratum events
           description: 'This application has loaded for the first time',
-          id: 1 // Very important reference identifier -- the key to simple queries
+          id: 1 // Very important reference identifier -- the key to simple queries (can be omitted to use the event key as id)
         }
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@capitalone/stratum-observability",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@capitalone/stratum-observability",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@rollup/plugin-replace": "^5.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capitalone/stratum-observability",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Library for defining and publishing observability events through plugin-based architecture",
   "license": "Apache-2.0",
   "repository": {

--- a/src/base/model.ts
+++ b/src/base/model.ts
@@ -77,7 +77,7 @@ export class BaseEventModel<T extends CatalogEvent = CatalogEvent> {
    * Getter function to return the id of the catalog item.
    */
   get id() {
-    return this.item.id;
+    return this.item.id ?? this.key;
   }
 
   /**

--- a/src/types/catalog.ts
+++ b/src/types/catalog.ts
@@ -34,7 +34,7 @@ export interface CatalogEvent<EventType extends string = string> {
   /**
    * Unique identifier for the item within the catalog
    */
-  id: EventId;
+  id?: EventId;
 }
 
 /**

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -92,7 +92,10 @@ describe('stratum service base functionality', () => {
     expect(catalog.validModels[4]).toBeInstanceOf(AModel);
 
     expect(Object.keys(stratum.injector.registeredEventIds)).toHaveLength(1);
-    const idObject = Object.values(SAMPLE_A_CATALOG).reduce((obj, x) => Object.assign(obj, { [x.id]: true }), {});
+    const idObject = Object.entries(SAMPLE_A_CATALOG).reduce(
+      (obj, [key, x]) => Object.assign(obj, { [x.id ?? key]: true }),
+      {}
+    );
     expect(stratum.injector.registeredEventIds[METADATA_CATALOG_ID]).toEqual(idObject);
   });
 
@@ -107,7 +110,10 @@ describe('stratum service base functionality', () => {
     expect(Object.keys(catalog?.validModels)).toHaveLength(catalog1Length);
 
     expect(Object.keys(stratum.injector.registeredEventIds)).toHaveLength(1);
-    const idObject = Object.values(SAMPLE_A_CATALOG).reduce((obj, x) => Object.assign(obj, { [x.id]: true }), {});
+    const idObject = Object.entries(SAMPLE_A_CATALOG).reduce(
+      (obj, [key, x]) => Object.assign(obj, { [x.id ?? key]: true }),
+      {}
+    );
     expect(stratum.injector.registeredEventIds[DEFAULT_CATALOG_ID]).toEqual(idObject);
   });
 

--- a/tests/simple.test.ts
+++ b/tests/simple.test.ts
@@ -3,6 +3,7 @@ import { PRODUCT_NAME, PRODUCT_VERSION } from './utils/constants';
 import { enableDebugMode, mockSessionId, restoreStratumMocks } from './utils/helpers';
 import { BASE_CATALOG } from './utils/catalog';
 import { BASE_EVENT_MOCK } from './utils/fixtures';
+import { BrowserConsolePlugin } from '../src/plugins/browser-console';
 
 describe('load stratum without plugins', () => {
   let stratum: StratumService;
@@ -29,6 +30,38 @@ describe('load stratum without plugins', () => {
       expect(catalog).toBeDefined();
       expect(catalog.isValid).toBe(true);
       expect(Object.keys(catalog.validModels)).toStrictEqual(['1', '2']);
+    });
+
+    it('should use event key as id when id field is omitted', () => {
+      const stratumWithPlugin = new StratumService({
+        productName: 'test',
+        productVersion: '1.0',
+        plugins: [new BrowserConsolePlugin()],
+        catalog: {
+          items: {
+            'app-loaded': {
+              eventType: 'base',
+              description: 'Application loaded'
+              // id field omitted - should use 'app-loaded' as the id
+            },
+            'user-login': {
+              eventType: 'base',
+              description: 'User logged in',
+              id: 'custom-id' // explicit id should still work
+            }
+          }
+        }
+      });
+
+      const catalog = stratumWithPlugin.defaultCatalog;
+      expect(catalog).toBeDefined();
+      expect(catalog?.isValid).toBe(true);
+
+      // Verify that the omitted id uses the key
+      expect(catalog?.validModels['app-loaded'].id).toBe('app-loaded');
+
+      // Verify that explicit id still works
+      expect(catalog?.validModels['user-login'].id).toBe('custom-id');
     });
   });
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -97,7 +97,7 @@ describe('util functions', () => {
         expect(Object.keys(catalog.validModels)).toHaveLength(1);
         expect(Object.keys(catalog.errors)).toHaveLength(4);
         expect(catalog.errors[0].errors).toHaveLength(1);
-        expect(catalog.errors[1].errors).toHaveLength(2);
+        expect(catalog.errors[1].errors).toHaveLength(1);
         expect(catalog.errors[3].errors).toHaveLength(1);
         expect(catalog.errors['duplicate'].errors).toHaveLength(1);
       });


### PR DESCRIPTION
### Summary

This PR introduces a small, backward-compatible enhancement:  
**If a catalog item omits the `id` field, the event key will be used as the ID.**

- The `id` field in `CatalogEvent` is now optional.
- The model logic uses the event key as the ID if `id` is not provided.
- Validation and all logic work with the computed ID (either the explicit `id` or the key).
- All existing and new tests pass, and a new test specifically covers this feature.

### Motivation

- Reduces boilerplate for catalog definitions.
- Makes it easier to keep event keys and IDs in sync.
- Maintains full backward compatibility: explicit `id` fields still work as before.

### Changes

- **src/types/catalog.ts**: Made `id` optional in `CatalogEvent`.
- **src/base/model.ts**: The model’s `id` getter returns `item.id ?? key`. Validation uses the computed ID.
- **tests/simple.test.ts**: Added a test to verify that omitting `id` uses the event key as the ID.
- **tests/utils.test.ts** and **tests/service.test.ts**: Updated to handle optional `id` and fallback to key.

### Documentation

- A minimal note was added to the README example to indicate that `id` can be omitted and the event key will be used.

### Test Plan

- All existing tests pass.
- New test verifies the new behavior.
- Run `npm test` to confirm.

### Checklist

- [x] Code changes are minimal and backward compatible
- [x] Tests added/updated and passing
- [x] Documentation minimally updated