### PR TITLE
chore: npm publish suggested uri fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/capitalone/Stratum-Observability.git"
+    "url": "git+https://github.com/capitalone/Stratum-Observability.git"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
During last npm publish, npm made me run a fix command that made the following change. 

#### ✔️ Checklist

Please review our [Contributor Docs](https://github.com/capitalone/Stratum-Observability/blob/main/CONTRIBUTING.md) for more details

* ~[ ] Fixes #REPLACE_WITH_ISSUE_NUMBER~
* ~[ ] I have run `npm version [patch, minor, major]` (considering (semantic versioning)[https://semver.org/#summary)) for a new release if needed~
* ~[ ] If the package version changed, this PR's title is prefixed with `release([VERSION]): `~
* ~[ ] I have added [typedoc-style comments](https://typedoc.org/example/) to my changes to improve the developer experience~

----

**⏩ Next steps:**
- Please ensure that all the automated pipeline steps pass
- Once your PR is opened, CODEOWNERS will be requested as reviewers. At least one review from a CODEOWNER is required to merge your PR
- Once approved, a CODEOWNER will merge your changes and perform any other necessary release tasks
