### PR TITLE
ci: add ignore-scripts flag on ci install

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -25,7 +25,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm run ci:pipeline
 
       - name: Build library
         run: npm run build
@@ -47,7 +47,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm run ci:pipeline
 
       - name: Build library
         run: npm run build
@@ -70,7 +70,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm run ci:pipeline
 
       - name: Lint code
         run: npm run prettier:check && npm run lint:check

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "build:clean": "rimraf dist",
     "build:lib": "rollup -c --bundleConfigAsCjs",
     "build:watch": "npm run build:clean && npm run build:lib -- --watch",
+    "ci:pipeline": "npm ci --ignore-scripts",
     "lint": "eslint --config ./.eslintrc.js --max-warnings 0 'src/**/*.{js,ts}' --fix",
     "lint:check": "eslint --config ./.eslintrc.js --max-warnings 0 'src/**/*.{js,ts}'",
     "pre-commit": "lint-staged",


### PR DESCRIPTION
Based on best-practices, we add `--ignore-scripts` in our pipeline to prevent postinstall hooks from running during automated builds.

See: https://www.stepsecurity.io/blog/axios-compromised-on-npm-malicious-versions-drop-remote-access-trojan