### PR TITLE
release(2.0.1): adds prepublishOnly script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@capitalone/stratum-observability",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@capitalone/stratum-observability",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@biomejs/biome": "2.4.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capitalone/stratum-observability",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Library for defining and publishing observability events through plugin-based architecture",
   "license": "Apache-2.0",
   "repository": {
@@ -45,6 +45,7 @@
     "lint:check": "biome check --no-errors-on-unmatched --error-on-warnings",
     "pre-commit": "npm run lint:check -- --staged",
     "prepare": "husky",
+    "prepublishOnly": "npm run build",
     "test": "jest --coverage=false",
     "test:coverage": "jest"
   },


### PR DESCRIPTION
- Adds `prepublishOnly` script to build the project prior to `npm publish`
- Bumps 2.x version to new patch version